### PR TITLE
Add last round filter and check putt make rate

### DIFF
--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -193,7 +193,7 @@ export function StatsDashboard({ userId }: StatsDashboardProps) {
       <div className="card">
         <h3 className="text-lg font-semibold text-masters-dark-green mb-4">Filtro de Estadísticas</h3>
         <div className="flex gap-2 flex-wrap">
-          {(['Todas', 'Últimas 5 rondas', 'Últimas 20 rondas'] as FilterOption[]).map((option) => (
+          {(['Todas', 'Última Ronda', 'Últimas 5 rondas', 'Últimas 20 rondas'] as FilterOption[]).map((option) => (
             <button
               key={option}
               onClick={() => setFilter(option)}

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -74,7 +74,9 @@ export const statsService = {
       .eq('user_id', userId)
       .order('timestamp', { ascending: false });
 
-    if (filter === 'Últimas 5 rondas') {
+    if (filter === 'Última Ronda') {
+      query = query.limit(1);
+    } else if (filter === 'Últimas 5 rondas') {
       query = query.limit(5);
     } else if (filter === 'Últimas 20 rondas') {
       query = query.limit(20);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,4 +61,4 @@ export interface DistanceInterval {
   max: number;
 }
 
-export type FilterOption = 'Todas' | 'Últimas 5 rondas' | 'Últimas 20 rondas'; 
+export type FilterOption = 'Todas' | 'Última Ronda' | 'Últimas 5 rondas' | 'Últimas 20 rondas'; 


### PR DESCRIPTION
Adds 'Última Ronda' filter to statistics dashboard and confirms putt make rate calculation is correct.

The putt make rate calculation was audited and confirmed to correctly measure the percentage of putts made within specified distance bands.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7c126cc-14c1-46d4-8f96-29faae584bf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7c126cc-14c1-46d4-8f96-29faae584bf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

